### PR TITLE
Fixes deprecated constructors

### DIFF
--- a/lib/salesforce_admin.class.php
+++ b/lib/salesforce_admin.class.php
@@ -10,7 +10,7 @@ class Salesforce_Admin extends OV_Plugin_Admin {
 	public $homepage;
 	public $ozhicon;
 
-	function Salesforce_Admin() {
+	function __construct() {
 
 		$this->optionname = 'salesforce2';
 

--- a/lib/salesforce_widget.class.php
+++ b/lib/salesforce_widget.class.php
@@ -1,7 +1,7 @@
 <?php
 class Salesforce_WordPress_to_Lead_Widgets extends WP_Widget {
 
-	function Salesforce_WordPress_to_Lead_Widgets() {
+	function __construct() {
 		$widget_ops = array( 'classname' => 'salesforce', 'description' => __('Displays a WordPress-to-Lead for Salesforce Form','salesforce') );
 		$control_ops = array( 'width' => 200, 'height' => 250, 'id_base' => 'salesforce' );
 		parent::__construct( 'salesforce', 'Salesforce', $widget_ops, $control_ops );

--- a/lib/yst_plugin_tools.php
+++ b/lib/yst_plugin_tools.php
@@ -17,7 +17,7 @@ if (!class_exists('Yoast_Plugin_Admin')) {
 		var $homepage	= '';
 		var $accesslvl	= 'manage_options';
 		
-		function Yoast_Plugin_Admin() {
+		function __construct() {
 			add_action( 'admin_menu', array(&$this, 'register_settings_page') );
 			add_filter( 'plugin_action_links', array(&$this, 'add_action_link'), 10, 2 );
 			add_filter( 'ozh_adminmenu_icon', array(&$this, 'add_ozh_adminmenu_icon' ) );				


### PR DESCRIPTION
There are notices on PHP 7.0:

```
PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; Salesforce_Admin has a deprecated constructor in .../wp-content/plugins/salesforce-wordpress-to-lead/lib/salesforce_admin.class.php on line 2
PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; Salesforce_WordPress_to_Lead_Widgets has a deprecated constructor in .../wp-content/plugins/salesforce-wordpress-to-lead/lib/salesforce_widget.class.php on line 2
```
This PR replaces deprecated PHP constructors with `__construct()`.
